### PR TITLE
feat: Add device summary support for improved performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'distribution'
 
 allprojects {
 	group = 'com.sitewhere'
-	version = '3.0.0.beta6'
+	version = '3.0.0.beta7'
 
 	repositories {
 		maven { url "https://repo.maven.apache.org/maven2" }

--- a/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/DeviceAssignmentSummary.java
+++ b/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/DeviceAssignmentSummary.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) SiteWhere, LLC. All rights reserved. http://www.sitewhere.com
+ *
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package com.sitewhere.rest.model.device;
+
+import java.util.Date;
+import java.util.UUID;
+
+import com.sitewhere.rest.model.common.PersistentEntity;
+import com.sitewhere.spi.device.DeviceAssignmentStatus;
+import com.sitewhere.spi.device.IDeviceAssignmentSummary;
+
+/**
+ * Summarizes device and directly related entities such as device type and
+ * assignments.
+ */
+public class DeviceAssignmentSummary extends PersistentEntity implements IDeviceAssignmentSummary {
+
+    /** Serial version UID */
+    private static final long serialVersionUID = -6857027037347179506L;
+
+    /** Id of assigned customer */
+    private UUID customerId;
+
+    /** Customer name */
+    private String customerName;
+
+    /** Customer image url */
+    private String customerImageUrl;
+
+    /** Id of assigned area */
+    private UUID areaId;
+
+    /** Area name */
+    private String areaName;
+
+    /** Area image url */
+    private String areaImageUrl;
+
+    /** Id of assigned asset */
+    private UUID assetId;
+
+    /** Asset name */
+    private String assetName;
+
+    /** Asset image url */
+    private String assetImageUrl;
+
+    /** Assignment status */
+    private DeviceAssignmentStatus status;
+
+    /** Assignment start date */
+    private Date activeDate;
+
+    /** Assignment end date */
+    private Date releasedDate;
+
+    @Override
+    public UUID getCustomerId() {
+	return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+	this.customerId = customerId;
+    }
+
+    @Override
+    public String getCustomerName() {
+	return customerName;
+    }
+
+    public void setCustomerName(String customerName) {
+	this.customerName = customerName;
+    }
+
+    @Override
+    public String getCustomerImageUrl() {
+	return customerImageUrl;
+    }
+
+    public void setCustomerImageUrl(String customerImageUrl) {
+	this.customerImageUrl = customerImageUrl;
+    }
+
+    @Override
+    public UUID getAreaId() {
+	return areaId;
+    }
+
+    public void setAreaId(UUID areaId) {
+	this.areaId = areaId;
+    }
+
+    @Override
+    public String getAreaName() {
+	return areaName;
+    }
+
+    public void setAreaName(String areaName) {
+	this.areaName = areaName;
+    }
+
+    @Override
+    public String getAreaImageUrl() {
+	return areaImageUrl;
+    }
+
+    public void setAreaImageUrl(String areaImageUrl) {
+	this.areaImageUrl = areaImageUrl;
+    }
+
+    @Override
+    public UUID getAssetId() {
+	return assetId;
+    }
+
+    public void setAssetId(UUID assetId) {
+	this.assetId = assetId;
+    }
+
+    @Override
+    public String getAssetName() {
+	return assetName;
+    }
+
+    public void setAssetName(String assetName) {
+	this.assetName = assetName;
+    }
+
+    @Override
+    public String getAssetImageUrl() {
+	return assetImageUrl;
+    }
+
+    public void setAssetImageUrl(String assetImageUrl) {
+	this.assetImageUrl = assetImageUrl;
+    }
+
+    @Override
+    public DeviceAssignmentStatus getStatus() {
+	return status;
+    }
+
+    public void setStatus(DeviceAssignmentStatus status) {
+	this.status = status;
+    }
+
+    @Override
+    public Date getActiveDate() {
+	return activeDate;
+    }
+
+    public void setActiveDate(Date activeDate) {
+	this.activeDate = activeDate;
+    }
+
+    @Override
+    public Date getReleasedDate() {
+	return releasedDate;
+    }
+
+    public void setReleasedDate(Date releasedDate) {
+	this.releasedDate = releasedDate;
+    }
+}

--- a/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/DeviceSummary.java
+++ b/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/DeviceSummary.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) SiteWhere, LLC. All rights reserved. http://www.sitewhere.com
+ *
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package com.sitewhere.rest.model.device;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.sitewhere.rest.model.common.PersistentEntity;
+import com.sitewhere.spi.device.IDeviceAssignmentSummary;
+import com.sitewhere.spi.device.IDeviceSummary;
+
+/**
+ * Device summary information including device type details and device
+ * assignment summaries.
+ */
+public class DeviceSummary extends PersistentEntity implements IDeviceSummary {
+
+    /** Serial version UID */
+    private static final long serialVersionUID = -4556277285202746345L;
+
+    /** Device type id */
+    private UUID deviceTypeId;
+
+    /** Device type name */
+    private String deviceTypeName;
+
+    /** Device type image url */
+    private String deviceTypeImageUrl;
+
+    /** Parent device id (if nested) */
+    private UUID parentDeviceId;
+
+    /** Comments */
+    private String comments;
+
+    /** Status indicator */
+    private String status;
+
+    /** Device assignment summaries */
+    private List<IDeviceAssignmentSummary> deviceAssignmentSummaries;
+
+    @Override
+    public UUID getDeviceTypeId() {
+	return deviceTypeId;
+    }
+
+    public void setDeviceTypeId(UUID deviceTypeId) {
+	this.deviceTypeId = deviceTypeId;
+    }
+
+    @Override
+    public String getDeviceTypeName() {
+	return deviceTypeName;
+    }
+
+    public void setDeviceTypeName(String deviceTypeName) {
+	this.deviceTypeName = deviceTypeName;
+    }
+
+    @Override
+    public String getDeviceTypeImageUrl() {
+	return deviceTypeImageUrl;
+    }
+
+    public void setDeviceTypeImageUrl(String deviceTypeImageUrl) {
+	this.deviceTypeImageUrl = deviceTypeImageUrl;
+    }
+
+    @Override
+    public UUID getParentDeviceId() {
+	return parentDeviceId;
+    }
+
+    public void setParentDeviceId(UUID parentDeviceId) {
+	this.parentDeviceId = parentDeviceId;
+    }
+
+    @Override
+    public String getComments() {
+	return comments;
+    }
+
+    public void setComments(String comments) {
+	this.comments = comments;
+    }
+
+    @Override
+    public String getStatus() {
+	return status;
+    }
+
+    public void setStatus(String status) {
+	this.status = status;
+    }
+
+    @Override
+    public List<IDeviceAssignmentSummary> getDeviceAssignmentSummaries() {
+	return deviceAssignmentSummaries;
+    }
+
+    public void setDeviceAssignmentSummaries(List<IDeviceAssignmentSummary> deviceAssignmentSummaries) {
+	this.deviceAssignmentSummaries = deviceAssignmentSummaries;
+    }
+}

--- a/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/marshaling/MarshaledDevice.java
+++ b/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/marshaling/MarshaledDevice.java
@@ -10,7 +10,6 @@ package com.sitewhere.rest.model.device.marshaling;
 import java.util.List;
 
 import com.sitewhere.rest.model.device.Device;
-import com.sitewhere.rest.model.device.DeviceAssignment;
 import com.sitewhere.rest.model.device.DeviceType;
 
 /**
@@ -25,7 +24,7 @@ public class MarshaledDevice extends Device {
     private DeviceType deviceType;
 
     /** Current device assignment */
-    private List<DeviceAssignment> activeDeviceAssignments;
+    private List<MarshaledDeviceAssignment> activeDeviceAssignments;
 
     public DeviceType getDeviceType() {
 	return deviceType;
@@ -35,11 +34,11 @@ public class MarshaledDevice extends Device {
 	this.deviceType = deviceType;
     }
 
-    public List<DeviceAssignment> getActiveDeviceAssignments() {
+    public List<MarshaledDeviceAssignment> getActiveDeviceAssignments() {
 	return activeDeviceAssignments;
     }
 
-    public void setActiveDeviceAssignments(List<DeviceAssignment> activeDeviceAssignments) {
+    public void setActiveDeviceAssignments(List<MarshaledDeviceAssignment> activeDeviceAssignments) {
 	this.activeDeviceAssignments = activeDeviceAssignments;
     }
 }

--- a/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/marshaling/MarshaledDeviceAssignment.java
+++ b/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/marshaling/MarshaledDeviceAssignment.java
@@ -31,24 +31,6 @@ public class MarshaledDeviceAssignment extends DeviceAssignment {
     /** Associated asset */
     private MarshaledAsset asset;
 
-    /** Customer name */
-    private String customerName;
-
-    /** Customer image url */
-    private String customerImageUrl;
-
-    /** Area name */
-    private String areaName;
-
-    /** Area image url */
-    private String areaImageUrl;
-
-    /** Associated asset name */
-    private String assetName;
-
-    /** Associated asset image */
-    private String assetImageUrl;
-
     public MarshaledDevice getDevice() {
 	return device;
     }
@@ -79,53 +61,5 @@ public class MarshaledDeviceAssignment extends DeviceAssignment {
 
     public void setAsset(MarshaledAsset asset) {
 	this.asset = asset;
-    }
-
-    public String getCustomerName() {
-	return customerName;
-    }
-
-    public void setCustomerName(String customerName) {
-	this.customerName = customerName;
-    }
-
-    public String getCustomerImageUrl() {
-	return customerImageUrl;
-    }
-
-    public void setCustomerImageUrl(String customerImageUrl) {
-	this.customerImageUrl = customerImageUrl;
-    }
-
-    public String getAreaName() {
-	return areaName;
-    }
-
-    public void setAreaName(String areaName) {
-	this.areaName = areaName;
-    }
-
-    public String getAreaImageUrl() {
-	return areaImageUrl;
-    }
-
-    public void setAreaImageUrl(String areaImageUrl) {
-	this.areaImageUrl = areaImageUrl;
-    }
-
-    public String getAssetName() {
-	return assetName;
-    }
-
-    public void setAssetName(String assetName) {
-	this.assetName = assetName;
-    }
-
-    public String getAssetImageUrl() {
-	return assetImageUrl;
-    }
-
-    public void setAssetImageUrl(String assetImageUrl) {
-	this.assetImageUrl = assetImageUrl;
     }
 }

--- a/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/marshaling/MarshaledDeviceAssignment.java
+++ b/sitewhere-java-model/src/main/java/com/sitewhere/rest/model/device/marshaling/MarshaledDeviceAssignment.java
@@ -31,6 +31,18 @@ public class MarshaledDeviceAssignment extends DeviceAssignment {
     /** Associated asset */
     private MarshaledAsset asset;
 
+    /** Customer name */
+    private String customerName;
+
+    /** Customer image url */
+    private String customerImageUrl;
+
+    /** Area name */
+    private String areaName;
+
+    /** Area image url */
+    private String areaImageUrl;
+
     /** Associated asset name */
     private String assetName;
 
@@ -67,6 +79,38 @@ public class MarshaledDeviceAssignment extends DeviceAssignment {
 
     public void setAsset(MarshaledAsset asset) {
 	this.asset = asset;
+    }
+
+    public String getCustomerName() {
+	return customerName;
+    }
+
+    public void setCustomerName(String customerName) {
+	this.customerName = customerName;
+    }
+
+    public String getCustomerImageUrl() {
+	return customerImageUrl;
+    }
+
+    public void setCustomerImageUrl(String customerImageUrl) {
+	this.customerImageUrl = customerImageUrl;
+    }
+
+    public String getAreaName() {
+	return areaName;
+    }
+
+    public void setAreaName(String areaName) {
+	this.areaName = areaName;
+    }
+
+    public String getAreaImageUrl() {
+	return areaImageUrl;
+    }
+
+    public void setAreaImageUrl(String areaImageUrl) {
+	this.areaImageUrl = areaImageUrl;
     }
 
     public String getAssetName() {

--- a/sitewhere-java-model/src/main/java/com/sitewhere/spi/device/IDeviceAssignmentSummary.java
+++ b/sitewhere-java-model/src/main/java/com/sitewhere/spi/device/IDeviceAssignmentSummary.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) SiteWhere, LLC. All rights reserved. http://www.sitewhere.com
+ *
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package com.sitewhere.spi.device;
+
+import java.util.Date;
+import java.util.UUID;
+
+import com.sitewhere.spi.common.IPersistentEntity;
+
+/**
+ * Summarizes basic details for a device assignment such as associated entities.
+ */
+public interface IDeviceAssignmentSummary extends IPersistentEntity {
+
+    /**
+     * Get unqiue id for customer assigned to device.
+     * 
+     * @return
+     */
+    UUID getCustomerId();
+
+    /**
+     * Get customer name.
+     * 
+     * @return
+     */
+    String getCustomerName();
+
+    /**
+     * Get customer image url.
+     * 
+     * @return
+     */
+    String getCustomerImageUrl();
+
+    /**
+     * Get unique id for area assigned to device.
+     * 
+     * @return
+     */
+    UUID getAreaId();
+
+    /**
+     * Get area name.
+     * 
+     * @return
+     */
+    String getAreaName();
+
+    /**
+     * Get area image url.
+     * 
+     * @return
+     */
+    String getAreaImageUrl();
+
+    /**
+     * Get asset id.
+     * 
+     * @return
+     */
+    UUID getAssetId();
+
+    /**
+     * Get asset name.
+     * 
+     * @return
+     */
+    String getAssetName();
+
+    /**
+     * Get asset image url.
+     * 
+     * @return
+     */
+    String getAssetImageUrl();
+
+    /**
+     * Get the device assignment status.
+     * 
+     * @return
+     */
+    DeviceAssignmentStatus getStatus();
+
+    /**
+     * Get the date/time at which the assignment was made active.
+     * 
+     * @return
+     */
+    Date getActiveDate();
+
+    /**
+     * Get the date/time at which the assignment was released.
+     * 
+     * @return
+     */
+    Date getReleasedDate();
+}

--- a/sitewhere-java-model/src/main/java/com/sitewhere/spi/device/IDeviceSummary.java
+++ b/sitewhere-java-model/src/main/java/com/sitewhere/spi/device/IDeviceSummary.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) SiteWhere, LLC. All rights reserved. http://www.sitewhere.com
+ *
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package com.sitewhere.spi.device;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.sitewhere.spi.common.IPersistentEntity;
+
+/**
+ * Summarizes device and directly related entities such as device type and
+ * assignments.
+ */
+public interface IDeviceSummary extends IPersistentEntity {
+
+    /**
+     * Get unique id for associated device type.
+     * 
+     * @return
+     */
+    UUID getDeviceTypeId();
+
+    /**
+     * Get device type name.
+     * 
+     * @return
+     */
+    String getDeviceTypeName();
+
+    /**
+     * Get device type image url.
+     * 
+     * @return
+     */
+    String getDeviceTypeImageUrl();
+
+    /**
+     * If contained by a parent device, returns the parent device id.
+     * 
+     * @return
+     */
+    UUID getParentDeviceId();
+
+    /**
+     * Get device comments.
+     * 
+     * @return
+     */
+    String getComments();
+
+    /**
+     * Get most recent device status.
+     * 
+     * @return
+     */
+    String getStatus();
+
+    /**
+     * Get list of device assignment summaries.
+     * 
+     * @return
+     */
+    List<? extends IDeviceAssignmentSummary> getDeviceAssignmentSummaries();
+}


### PR DESCRIPTION
Device summaries are used in the APIs to support more efficient querying of device/assignment data to prevent multiple round-trips to the device management microservice.